### PR TITLE
Fix example code documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,9 +75,8 @@ const liquidity = require('liquidity-sdk')
 const to = '0x627306090abaB3A6e1400e9345bC60c78a8BEf57'
 const amount = 32
 
-const performedTransfer = await liquidity.transfers.send(to, amount)
-
-console.log(`Tranfer has been ${performedTranfer}`)
+liquidity.transfers.send(to, amount)
+  .then(performedTransfer => console.log(`Tranfer has been ${performedTranfer}`))
 ```
 
 


### PR DESCRIPTION
Hi, the first code example of the docs does not works.
```await``` must be called inside an async function, an alternative could be:
```js
const liquidity = require('liquidity-sdk')

const to = '0x627306090abaB3A6e1400e9345bC60c78a8BEf57'
const amount = 32

const printTransfer = async () => {
  const performedTransfer = await liquidity.transfers.send(to, amount)
  console.log(`Tranfer has been ${performedTranfer}`)
}

printTransfer()
```

But I think that in this case could be better to use ```then```, the meaning of the code is more intuitive and compact.
